### PR TITLE
fix: replace Array.Empty<byte>() with new byte[0] for net40 compat

### DIFF
--- a/Sharpire/Empire.Agent.Coms.cs
+++ b/Sharpire/Empire.Agent.Coms.cs
@@ -364,7 +364,7 @@ AESc = AES encrypted using the client's session key
             // each inner frame is a 12-byte header plus payload.
             const int HEADER_SIZE = 12;
             int offset = 0;
-            byte[] resultPackets = Array.Empty<byte>();
+            byte[] resultPackets = new byte[0];
             while (offset < taskingBytes.Length)
             {
                 if (taskingBytes.Length - offset < HEADER_SIZE)


### PR DESCRIPTION
## Summary
- `Sharpire/Empire.Agent.Coms.cs:367` used `Array.Empty<byte>()`, which was added in .NET Framework 4.6, but Empire Compiler's default `compile_stager` target is `net40` — so any stager whose generation path runs through `ProcessTaskingPackets` fails to build with `error CS0117: 'Array' does not contain a definition for 'Empty'`.
- Replaced with `new byte[0]`, matching the convention used everywhere else in this repo (Empire.Agent.Jobs.cs:53, Empire.Agent.cs:141/181, Empire.Agent.AesGcm.cs:92, SharpireMalleable).
- The single-line introduction came in via #19; everything else in that PR is fine.

## Repro (before this fix)
1. Empire Compiler ≥ v1.1.0-a.x bundles this Sharpire source.
2. `./ps-empire server`, then generate a `csharp_exe` stager (default `DotNetVersion: net40`).
3. Compile fails with the CS0117 above and a `ModuleExecutionException` from `dotnet.py:114`.

## Test plan
- [ ] Sharpire's CI build passes
- [ ] Generate a csharp_exe stager against an Empire server using a compiler that bundles this branch — stager produced without CS0117
- [ ] Stager runs against an http listener and checks in (regression check on the multi-packet tasking handler from #19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)